### PR TITLE
Add OCC file build button in admin

### DIFF
--- a/upload_STEP/admin.py
+++ b/upload_STEP/admin.py
@@ -10,4 +10,5 @@ class StepFileAdmin(admin.ModelAdmin):
     """Admin representation of :class:`~upload_STEP.models.StepFile`."""
 
     list_display = ("id", "file", "uploaded_at")
+    change_list_template = "admin/upload_STEP/stepfile/change_list.html"
 

--- a/upload_STEP/templates/admin/upload_STEP/stepfile/change_list.html
+++ b/upload_STEP/templates/admin/upload_STEP/stepfile/change_list.html
@@ -1,0 +1,50 @@
+{% extends "admin/change_list.html" %}
+{% load admin_urls %}
+
+{% block object-tools %}
+  {% if has_add_permission %}
+    <ul class="object-tools">
+      <li>
+        <a href="{% url cl.opts|admin_urlname:'add' %}" class="addlink">Add {{ cl.opts.verbose_name }}</a>
+      </li>
+      <li>
+        <a href="#" class="button" id="build-occ">Build OCC file</a>
+      </li>
+    </ul>
+  {% endif %}
+{% endblock %}
+
+{% block extrahead %}
+  {{ block.super }}
+  <style>
+    ul.object-tools {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+    }
+    ul.object-tools li {
+      margin-bottom: 5px;
+    }
+  </style>
+  <script>
+    document.addEventListener('DOMContentLoaded', function() {
+      const button = document.getElementById('build-occ');
+      if (!button) return;
+      button.addEventListener('click', function(event) {
+        event.preventDefault();
+        const selected = document.querySelectorAll('input.action-select:checked');
+        if (selected.length !== 1) {
+          alert('Please select exactly one STEP file to build an OCC file.');
+          return;
+        }
+        const row = selected[0].closest('tr');
+        const fileLink = row.querySelector('td.field-file a');
+        const fileName = fileLink ? fileLink.textContent.trim() : 'the selected file';
+        const message = `Are you sure you would like to use ${fileName} to generate a new OCC file?`;
+        if (confirm(message)) {
+          // Future functionality will be implemented later.
+        }
+      });
+    });
+  </script>
+{% endblock %}

--- a/upload_STEP/tests.py
+++ b/upload_STEP/tests.py
@@ -1,3 +1,24 @@
-from django.test import TestCase
+"""Tests for the ``upload_STEP`` application."""
 
-# Create your tests here.
+from django.contrib.auth import get_user_model
+from django.test import Client, TestCase
+from django.urls import reverse
+
+
+class AdminInterfaceTests(TestCase):
+    """Tests related to the Django admin interface."""
+
+    def setUp(self) -> None:
+        """Create a superuser and log them in for admin tests."""
+        user_model = get_user_model()
+        self.user = user_model.objects.create_superuser(
+            username="admin", email="admin@example.com", password="password"
+        )
+        self.client = Client()
+        self.client.force_login(self.user)
+
+    def test_build_occ_button_present(self) -> None:
+        """Ensure the ``Build OCC file`` button is rendered on the changelist."""
+        url = reverse("admin:upload_STEP_stepfile_changelist")
+        response = self.client.get(url)
+        self.assertContains(response, "Build OCC file")


### PR DESCRIPTION
## Summary
- add "Build OCC file" button to StepFile admin list
- prompt user to confirm selected STEP file before building OCC file
- test for presence of build button

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68949387fb6c832e85aeb20d3f92c78f