### PR TITLE
Use new application API for OCAF documents

### DIFF
--- a/edit_OCC/services.py
+++ b/edit_OCC/services.py
@@ -1,0 +1,40 @@
+"""Services for OCC-based document operations."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from OCC.Core.BinXCAFDrivers import BinXCAFDrivers
+from OCC.Core.IFSelect import IFSelect_RetDone
+from OCC.Core.STEPCAFControl import STEPCAFControl_Reader
+from OCC.Core.XCAFApp import XCAFApp_Application
+
+
+def build_ocaf_document(step_path: str | Path, ocaf_path: str | Path) -> None:
+    """Generate an OCAF document from a STEP file.
+
+    Parameters
+    ----------
+    step_path: Path-like
+        Location of the input STEP file.
+    ocaf_path: Path-like
+        Destination path for the generated OCAF document.
+
+    The function uses the BinXCAF format drivers to create a new document
+    and transfers the STEP contents into it before saving.
+    """
+    step_path = Path(step_path)
+    ocaf_path = Path(ocaf_path)
+
+    app = XCAFApp_Application.GetApplication()
+    BinXCAFDrivers.DefineFormat(app)
+
+    # Create the document handle using the newer API which directly returns it
+    doc = app.NewDocument("BinXCAF")
+
+    reader = STEPCAFControl_Reader()
+    status = reader.ReadFile(str(step_path))
+    if status != IFSelect_RetDone:
+        raise RuntimeError(f"Failed to read STEP file: {step_path}")
+
+    reader.Transfer(doc)
+    app.SaveAs(doc, str(ocaf_path))


### PR DESCRIPTION
## Summary
- Add `build_ocaf_document` service that uses `app.NewDocument("BinXCAF")`
- Transfer STEP data and save OCAF document via the returned handle

## Testing
- `python manage.py test`
- `pip install pythonocc-core==7.7.2` *(fails: No matching distribution found)*

------
https://chatgpt.com/codex/tasks/task_e_6894b0e5c3c8832e8ec9c5acd5dd433e